### PR TITLE
Upgrade to new Context API

### DIFF
--- a/src/authenticated.js
+++ b/src/authenticated.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { getLocalToken } from './local-token'
-import contextTypes from './context-types'
+import AuthContextType from './context-types'
 
 export function hashed(o) {
   return Object
@@ -31,6 +31,6 @@ export const authenticated = () => Component => {
       }
     }
   }
-  Authed.contextTypes = contextTypes
+  Authed.contextType = AuthContextType
   return Authed
 }

--- a/src/components/auth-context.js
+++ b/src/components/auth-context.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import contextTypes from '../context-types'
+import AuthContextType from '../context-types'
+import PropTypes from 'prop-types'
 import { getHashValues } from '../lib/utils'
 
 import TokenManager from './token-manager'
@@ -40,11 +41,6 @@ class Debug extends React.Component {
 }
 
 export class AuthContext extends React.Component {
-  getChildContext() {
-    const { provider, clientId, loggingInIndicator } = this.props
-    return { provider, clientId, loggingInIndicator }
-  }
-
   isDebugEnabled = () => {
     return !!(localStorage.getItem('debug') || '').match(/react-u5auth/)
   }
@@ -59,18 +55,23 @@ export class AuthContext extends React.Component {
     console.log('react-u5auth, debug', debug)
     return (
       <div>
-        <TokenManager
-          onTokenUpdate={token => {
-            this.setState({ token })
-            onTokenUpdate && onTokenUpdate(token)
-          }}
-        />
-        { debug && <Debug contextProps={contextProps} contextState={this.state} hashValues={state} />}
-        { showChildren && this.props.children }
+        <AuthContextType.Provider value={contextProps}>
+          <TokenManager
+            onTokenUpdate={token => {
+              this.setState({ token })
+              onTokenUpdate && onTokenUpdate(token)
+            }}
+          />
+          { debug && <Debug contextProps={contextProps} contextState={this.state} hashValues={state} />}
+          { showChildren && this.props.children }
+        </AuthContextType.Provider>
       </div>
     )
   }
 }
 
-AuthContext.propTypes = contextTypes
-AuthContext.childContextTypes = contextTypes
+AuthContext.propTypes = {
+  provider: PropTypes.string.isRequired,
+  clientId: PropTypes.string.isRequired,
+  loggingInIndicator: PropTypes.element
+}

--- a/src/components/token-manager.js
+++ b/src/components/token-manager.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { setLocalToken, getLocalToken, getLocalExpiresAt } from '../local-token'
-import contextTypes from '../context-types'
+import AuthContextType from '../context-types'
 import { hashed } from '../authenticated'
 import { getHashValues } from '../lib/utils'
 
@@ -169,6 +169,6 @@ class TokenManager extends React.Component {
   }
 }
 
-TokenManager.contextTypes = contextTypes
+TokenManager.contextType = AuthContextType
 
 export default TokenManager

--- a/src/context-types.js
+++ b/src/context-types.js
@@ -1,9 +1,5 @@
-import PropTypes from 'prop-types'
+import { createContext } from 'react'
 
-const contextTypes = {
-  provider: PropTypes.string.isRequired,
-  clientId: PropTypes.string.isRequired,
-  loggingInIndicator: PropTypes.element
-}
+const AuthContextType = createContext()
 
-export default contextTypes
+export default AuthContextType


### PR DESCRIPTION
Replaces the legacy/experimental context API with the new context API released in React 16.3.
See https://reactjs.org/docs/context.html