### PR TITLE
Fix token capture from the hidden iframe on refresh

### DIFF
--- a/src/components/token-manager.js
+++ b/src/components/token-manager.js
@@ -8,6 +8,8 @@ class TokenManager extends React.Component {
 
   state = { refreshing: false }
 
+  isRefreshingInIframe = false
+
   handleTokenUpdate(token, expires_in) {
     setLocalToken(token, expires_in)
     if (this.props.onTokenUpdate) {
@@ -130,7 +132,6 @@ class TokenManager extends React.Component {
 
   render() {
 
-    let isRefreshingInIframe = false
     const results = getHashValues()
 
     if (results.access_token) {
@@ -140,9 +141,9 @@ class TokenManager extends React.Component {
       // and, if state contains 'refreshing', then we are inside the
       // iframe, and therefore must break recursion
       if (state && state.match(/^refreshing/)) {
-        isRefreshingInIframe = true
+        this.isRefreshingInIframe = true
       }
-      if (expires_in && !isRefreshingInIframe) {
+      if (expires_in && !this.isRefreshingInIframe) {
         // expires_in = "75" // for testing
         this.setRefreshTimer(expires_in)
       }
@@ -151,7 +152,7 @@ class TokenManager extends React.Component {
 
     return (
       <div style={{ display: 'none' }}>
-        { isRefreshingInIframe &&
+        { this.isRefreshingInIframe &&
           <div>
             <div id="token">{ this.state.token }</div>
             <div id="expires_in">{ this.state.expires_in }</div>


### PR DESCRIPTION
This is a tricky one to explain.

It seems that the app inside the hidden iframe re-renders several times before the outer app tries to grab the token from it. This means that `isRefreshingInIframe` is no longer true in the `TokenManager` in the hidden iframe, so the `<div id="token">` is not rendered. This means that the outer app can't find the token when it looks for it, and it gets stuck in an infinite loop of "checked for new token, not found yet".

This PR makes `isRefreshingInIframe` an instance variable in the `TokenManager`, so it persists through the refreshes, so the token div is still there inside the iframe when the outer app comes looking for it.